### PR TITLE
Changed tmp path from /tmp-temp-values.toml to /tmp/temp-values.toml

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func mkdirr(path string) error {
 }
 
 func tempfile(p string) (string, error) {
-	tmp := fmt.Sprintf("%s.temp-%s", os.TempDir(), filepath.Base(p))
+	tmp := fmt.Sprintf("%s/temp-%s", os.TempDir(), filepath.Base(p))
 	pabs, err := filepath.Abs(p)
 
 	if err != nil {


### PR DESCRIPTION
Solves this issue:

```
go run main.go dockerfile
/tmp.temp-values.toml
/home/dev/.local/share/ska/dockerfile/values.toml
link /home/dev/.local/share/ska/dockerfile/values.toml /tmp.temp-values.toml: permission denied
exit status 255

```