### PR TITLE
Support templating in directory/filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 coverage.txt
 out
+.idea

--- a/examples/filenames/templates/{{.svc}}/{{.svc}}.txt
+++ b/examples/filenames/templates/{{.svc}}/{{.svc}}.txt
@@ -1,0 +1,1 @@
+Welcome to {{.svc}}

--- a/examples/filenames/values.toml
+++ b/examples/filenames/values.toml
@@ -1,0 +1,1 @@
+svc = "example"

--- a/main_test.go
+++ b/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -14,30 +16,64 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// TODO make it auto.
 func TestCompile(t *testing.T) {
-	t.Run("dockerfile", func(t *testing.T) {
-		ska := "examples"
-		tpl := "dockerfile"
-		out := "out/dockerfile"
+	tests := map[string]struct {
+		path string
+	}{
+		"a basic file with templated contents": {
+			path: "dockerfile",
+		},
+		"templated directory and filenames": {
+			path: "filenames",
+		},
+	}
 
-		vp, tp := tplPaths(ska, tpl)
+	for msg, test := range tests {
+		t.Run(msg, func(t *testing.T) {
+			ska := "examples"
+			tpl := test.path
+			goldenDir := path.Join("testdata", test.path)
+			outDir := path.Join("out", test.path)
 
-		vals, err := vals(vp)
-		must(err)
+			vp, tp := tplPaths(ska, tpl)
+			vals, err := vals(vp)
+			must(err)
+			must(walk(tp, outDir, vals, gen))
 
-		must(walk(tp, out, vals, gen))
+			err = filepath.Walk(goldenDir, func(goldenPath string, goldenInfo os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
 
-		outfile := fmt.Sprintf("%s/Dockerfile", out)
-		golden := "testdata/dockerfile/Dockerfile"
+				outPath := path.Join("out", strings.TrimPrefix(goldenPath, "testdata"))
 
-		if !isSame(t, outfile, golden) {
-			t.Fatal("Compiled and golden files not the same")
-		}
-	})
+				if goldenInfo.IsDir() {
+					outInfo, err := os.Stat(outPath)
+					if err != nil {
+						t.Fatalf("Error for expected output directory %s: %v", outPath, err)
+					}
+					if !outInfo.IsDir() {
+						t.Fatalf("Found file not directory for expected output directory %s", outPath)
+					}
+				} else {
+					if !hasSameContents(t, outPath, goldenPath) {
+						t.Fatalf("Compiled and golden files %s vs %s not the same", outPath, goldenPath)
+					}
+				}
+
+				return nil
+			})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.RemoveAll(outDir)
+
+		})
+	}
 }
 
-func isSame(t *testing.T, f1, f2 string) bool {
+func hasSameContents(t *testing.T, f1, f2 string) bool {
 	b1, err := ioutil.ReadFile(f1)
 	if err != nil {
 		t.Fatal(err)

--- a/testdata/filenames/example/example.txt
+++ b/testdata/filenames/example/example.txt
@@ -1,0 +1,1 @@
+Welcome to example


### PR DESCRIPTION
also automated the golden vs output test file comparison, and made the tests clean up after themselves on success.